### PR TITLE
fix: adicionado regex para remocao de caracteres

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ $('#generate-phone-link').addEventListener('click', ({target}) => {
         return;
     }
 
-    phoneNumber = value;
+    phoneNumber = value.replace(/[\(\)\-\s]/g, '');;
 
     containers.insertPhone.classList.add('none');
     containers.hasPhone.classList.remove('none');


### PR DESCRIPTION
Ao testar o serviço, utilizei o chrome para preencher o meu número e ele acrescentou parenteses, espaço e traço. Isso fez com que a api do whatsapp não entendesse e desse erro na hora de redirecionar para a conversa. Corrigi isso com um regex antes da chamada para a api